### PR TITLE
Add contract reference and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ The configuration will fall back to `env.json.sample` if `env.json` is missing.
 
 ## Run Tests
 `npx hardhat test`
+
+
+See `docs/DEVELOPER_GUIDE.md` for development notes.
+Additional documentation can be found in `docs/SMART_CONTRACT_OVERVIEW.md`.
+Deployment instructions live in `docs/DEPLOYMENT_GUIDE.md` and a
+full list of contracts is provided in `docs/CONTRACTS_REFERENCE.md`.

--- a/docs/CONTRACTS_REFERENCE.md
+++ b/docs/CONTRACTS_REFERENCE.md
@@ -1,0 +1,50 @@
+# Contract Reference
+
+This reference briefly describes the purpose of each contract in the repository. Contracts are grouped by directory.
+
+## `access`
+- **Governable** – base contract providing a `gov` address that can perform administrative actions.
+- **TokenManager** – manages a list of tokens and has the ability to mint/burn them.
+
+## `amm`
+- **PancakeFactory**, **PancakePair**, **PancakeRouter** – fork of Uniswap-style automated market maker for swaps.
+- **UniFactory**, **UniPool**, **UniNftManager** – minimal Uniswap V3-style components used for internal liquidity management.
+
+## `core`
+- **Vault** – central contract that holds assets and manages leveraged positions.
+- **Router** – main entry point for swaps and position adjustments.
+- **PositionManager**, **PositionRouter**, **BasePositionManager** – helpers that create and manage position orders.
+- **OrderBook** – stores swap/position orders for execution.
+- **ShortsTracker** – tracks global short positions.
+- **VaultErrorController**, **VaultUtils** – utility contracts for the vault.
+
+## `gmx`
+- **GMX**, **EsGMX**, **GLP** – token contracts for the GMX ecosystem.
+- **GmxMigrator**, **GmxIou**, **GmxFloor** – helper contracts for migrations and IOU handling.
+
+## `gambit-token`
+- **GMT** – Gambit token implementation.
+- **Treasury** – simple treasury for GMT funds.
+
+## `oracle`
+- **PriceFeed** – provides price data to the protocol.
+- **FastPriceFeed**, **FastPriceEvents** – oracle system for fast price updates.
+
+## `peripherals`
+- **Timelock**, **GmxTimelock**, **PriceFeedTimelock** – administrative timelocks.
+- **Reader**, **RewardReader**, **OrderBookReader** – view helpers that aggregate protocol data.
+- **BalanceUpdater**, **BatchSender**, **EsGmxBatchSender** – utility contracts for batch operations.
+
+## `referrals`
+- **ReferralStorage** – records referral relationships and discounts.
+- **ReferralReader** – view contract to read referral info.
+
+## `staking`
+- **RewardRouterV2**, **RewardRouter** – handle staking and unstaking for GMX and GLP.
+- **RewardTracker**, **RewardDistributor** – track rewards and distribute them over time.
+- **Vester** – contract for vesting esGMX to GMX.
+- **StakedGlp**, **StakedGlpMigrator** – GLP staking helpers.
+- **BonusDistributor**, **StakeManager**, **GlpBalance** – additional staking utilities.
+
+Interfaces are located under each directory's `interfaces` folder.
+

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -1,0 +1,36 @@
+# Deployment Guide
+
+This guide explains how to deploy the GMX contracts using Hardhat and interact with the protocol after deployment.
+
+## 1. Setup
+1. Copy `env.json.sample` to `env.json` and update RPC URLs and private keys.
+2. Install dependencies with `npm install`.
+
+## 2. Compile
+Run `npx hardhat compile` to build the Solidity contracts. Ensure your environment has internet access so Hardhat can download `solc`.
+
+## 3. Deploy
+Each subsystem has a deploy script in `scripts/`. For example, to deploy the core vault contracts:
+
+```bash
+npx hardhat run scripts/core/deployVault.js --network goerli
+```
+
+Deployment scripts log the address of each contract after the transaction is mined. The helper function `deployContract` prints a line similar to:
+
+```
+Deploying Vault ...
+... Completed deployment of Vault at 0xabc123...
+```
+
+All addresses for the current network are also written to `.tmp-addresses-<network>.json` for convenience.
+
+## 4. Using the Contracts
+After deployment you can interact with the contracts using Hardhat tasks, scripts or a frontend. Some common interactions:
+
+- Approve tokens to the `Router` then call `Router.swap` for token swaps.
+- Use `PositionRouter.createIncreasePosition` to open leveraged positions via the `Vault`.
+- Stake tokens through `RewardRouterV2` to earn rewards.
+
+Refer to `docs/CONTRACTS_REFERENCE.md` for a list of contracts and their purpose.
+

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,0 +1,20 @@
+# Developer Guide
+
+This repository is a fork of the GMX smart contracts. It uses Hardhat for development.
+
+## Prerequisites
+- Node.js v18 or newer
+- `npm install` to install dependencies
+
+### Environment
+Copy `env.json.sample` to `env.json` and adjust RPC URLs and private keys as needed. The config falls back to the sample file if `env.json` is missing.
+
+### Compilation
+Run `npx hardhat compile` to build the contracts. Hardhat downloads the Solidity compiler from the internet. If your environment uses an HTTP proxy or blocks external traffic, the download can fail. Remove `http_proxy` and `https_proxy` variables or configure network access before compiling.
+
+### Tests
+Run `npx hardhat test` to execute the test suite. Tests require successful compilation and a working Hardhat environment.
+
+### Troubleshooting
+If compilation fails with `HH502` errors, ensure your network connection allows access to `solc-bin`. You may also try setting `HARDHAT_SKIP_COMPILER_DOWNLOAD=false` and running behind a direct internet connection.
+

--- a/docs/SMART_CONTRACT_OVERVIEW.md
+++ b/docs/SMART_CONTRACT_OVERVIEW.md
@@ -1,0 +1,18 @@
+# Smart Contract Overview
+
+This project contains the core contracts used by the GMX protocol. They include staking, reward distribution, token contracts and various peripherals.
+
+- **staking** – contracts for reward tracking and vesting
+- **oracle** – price feeds and oracles
+- **gmx** – core GMX protocol logic
+
+All contracts target Solidity `0.6.12` and are compiled via Hardhat.
+
+For a directory-by-directory list of contracts see
+`docs/CONTRACTS_REFERENCE.md`. Instructions for deploying them can be found in
+`docs/DEPLOYMENT_GUIDE.md`.
+
+### Security considerations
+These contracts are security-critical. Review access control modifiers (e.g. `onlyGov`, `onlyAdmin`) and ensure external calls use appropriate reentrancy guards. Carefully validate arithmetic operations and token transfers.
+
+This repository provides tests under the `test/` directory which can be run with `npx hardhat test` once compilation succeeds.

--- a/scripts/shared/helpers.js
+++ b/scripts/shared/helpers.js
@@ -118,9 +118,9 @@ async function deployContract(name, args, label, options) {
     contract = await contractFactory.deploy(...args)
   }
   const argStr = args.map((i) => `"${i}"`).join(" ")
-  console.info(`Deploying ${info} ${contract.address} ${argStr}`)
+  console.info(`Deploying ${info} with args ${argStr}`)
   await contract.deployTransaction.wait()
-  console.info("... Completed!")
+  console.info(`... Completed deployment of ${info} at ${contract.address}`)
   return contract
 }
 


### PR DESCRIPTION
## Summary
- extend deployment helper logging to print deployed address
- document deployment procedure
- list contracts by directory for quick reference
- link new docs from README

## Testing
- `npx hardhat compile` *(fails: couldn't download compiler version list)*
- `npx hardhat test` *(fails: couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_b_684701d70b9c832f9a5ecc3cb5899e48